### PR TITLE
Feature: add Wayland support

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@
 - **Background Replacement** - Use any image as your background
 - **Background Blur**
 - **On-demand camera usage** - Camera (and processing power) is only used when needed
+- **Native Wayland and X11 support** - Auto-detects your display server for seamless integration
 
 ## Prerequisites
 
@@ -85,12 +86,27 @@ podman pull ghcr.io/andrei9383/blucast:latest
 # Setup virtual camera (requires v4l2loopback)
 sudo modprobe v4l2loopback devices=1 video_nr=10 card_label="BluCast Camera" exclusive_caps=1
 
-# Run
+# Run (X11)
 podman run --rm \
   --device nvidia.com/gpu=all \
   --device /dev/video0 \
   --device /dev/video10 \
   -e DISPLAY=$DISPLAY \
+  -v /tmp/.X11-unix:/tmp/.X11-unix \
+  -v $HOME/.config/blucast:/root/.config/blucast \
+  --network host \
+  ghcr.io/andrei9383/blucast:latest
+
+# Run (Wayland)
+podman run --rm \
+  --device nvidia.com/gpu=all \
+  --device /dev/video0 \
+  --device /dev/video10 \
+  -e DISPLAY=$DISPLAY \
+  -e WAYLAND_DISPLAY=$WAYLAND_DISPLAY \
+  -e XDG_RUNTIME_DIR=/tmp/runtime-root \
+  -e QT_QPA_PLATFORM=wayland \
+  -v $XDG_RUNTIME_DIR/$WAYLAND_DISPLAY:/tmp/runtime-root/$WAYLAND_DISPLAY \
   -v /tmp/.X11-unix:/tmp/.X11-unix \
   -v $HOME/.config/blucast:/root/.config/blucast \
   --network host \

--- a/scripts/install-remote.sh
+++ b/scripts/install-remote.sh
@@ -305,17 +305,34 @@ mkdir -p "$CONFIG_DIR"
 
 echo "Starting BluCast..."
 
+# --- Auto-detect Wayland vs X11 ---
+if [ -n "${WAYLAND_DISPLAY:-}" ] || [ "${XDG_SESSION_TYPE:-}" = "wayland" ]; then
+    WAYLAND_SOCK="${WAYLAND_DISPLAY:-wayland-0}"
+    GUI_ARGS=(
+        -e "QT_QPA_PLATFORM=wayland"
+        -e "WAYLAND_DISPLAY=$WAYLAND_SOCK"
+        -e "XDG_RUNTIME_DIR=/tmp/runtime-root"
+        -v "$XDG_RUNTIME_DIR/$WAYLAND_SOCK:/tmp/runtime-root/$WAYLAND_SOCK:rw"
+        -e "DISPLAY=${DISPLAY:-:0}"
+        -v "/tmp/.X11-unix:/tmp/.X11-unix:rw"
+    )
+else
+    GUI_ARGS=(
+        -e "QT_QPA_PLATFORM=xcb"
+        -e "DISPLAY=${DISPLAY:-:0}"
+        -e XDG_RUNTIME_DIR=/tmp/runtime-root
+        -v "/tmp/.X11-unix:/tmp/.X11-unix:rw"
+    )
+fi
+
 $CONTAINER_CMD run --rm \
     --security-opt label=disable \
     $GPU_ARGS \
     $CAMERA_ARGS \
-    -e DISPLAY="${DISPLAY:-:0}" \
     -e NVIDIA_DRIVER_CAPABILITIES=all \
     -e NVIDIA_VISIBLE_DEVICES=all \
-    -e QT_QPA_PLATFORM=xcb \
     -e QT_LOGGING_RULES="*.debug=false" \
-    -e XDG_RUNTIME_DIR=/tmp/runtime-root \
-    -v /tmp/.X11-unix:/tmp/.X11-unix:rw \
+    "${GUI_ARGS[@]}" \
     $XAUTH_ARGS \
     $DBUS_ARGS \
     -v "$HOME:/host_home:ro" \


### PR DESCRIPTION


## Description
When the run script is executed, it tries to detect if it is running on a wayland system to change the docker arguments accordingly. If not, it falls back to current behavior for x11.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Related Issues

No related issues


## Testing
Tested a fresh install on a cachyos system with hyprland. Have not retested on ubuntu or fedora, as I currently have neither available. But for these systems nothing changes, so it will not be affected. If needed I could see to maybe prepare an ubuntu system on the weekend and run some tests there.

- [x] Tested with different effect modes
- [x] Tested virtual camera output in a video app
- [x] Tested on my GPU: NVIDIA RTX 3080
- [x] No new warnings or errors

## Screenshots

Not applicable

## Checklist

- [x] My code follows the project's code style
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings
- [x] I have updated documentation if needed
