### PR TITLE
use modinfo as root

### DIFF
--- a/scripts/install-remote.sh
+++ b/scripts/install-remote.sh
@@ -50,7 +50,7 @@ fi
 
 echo -e "${BLUE}[2/5]${NC} Setting up virtual camera..."
 
-if ! modinfo v4l2loopback &>/dev/null 2>&1; then
+if ! sudo modinfo v4l2loopback &>/dev/null 2>&1; then
     echo "  Installing v4l2loopback..."
     if command -v dnf &>/dev/null; then
         sudo dnf install -y v4l2loopback kmod-v4l2loopback 2>/dev/null \
@@ -64,7 +64,7 @@ if ! modinfo v4l2loopback &>/dev/null 2>&1; then
         die "Unsupported package manager. Install v4l2loopback manually."
     fi
 fi
-modinfo v4l2loopback &>/dev/null 2>&1 || die "v4l2loopback module not available. Reboot may be needed."
+sudo modinfo v4l2loopback &>/dev/null 2>&1 || die "v4l2loopback module not available. Reboot may be needed."
 log "v4l2loopback module available"
 
 for tool_pkg in "lsof lsof" "fuser psmisc"; do


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->

Script fails on Debian Trixie 13.3 because `modinfo` is only available as root. Adding sudo in front of `modinfo` allows the script to install.

## Type of Change

<!-- Mark with an `x` all that apply -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Related Issues

<!-- Link any related issues here using #issue_number -->

Fixes #

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [ ] Tested with different effect modes
- [ ] Tested virtual camera output in a video app
- [ ] Tested on my GPU: <!-- specify model -->
- [x] No new warnings or errors

(Not pertaining : it only allows installation to complete on Debian 13)

## Screenshots

<!-- If applicable, add screenshots to demonstrate the changes -->

## Checklist

- [ ] My code follows the project's code style
- [ ] I have commented my code where necessary
- [x] My changes generate no new warnings
- [ ] I have updated documentation if needed
