### PR TITLE
Update VideoFX SDK runtime packaging

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,3 @@
-#FROM docker.io/nvidia/cuda:11.8.0-cudnn8-devel-ubuntu20.04 AS builder
 FROM docker.io/nvidia/cuda:12.9.1-cudnn-devel-ubuntu20.04 AS builder
 
 
@@ -23,7 +22,6 @@ RUN mkdir -p /build/blucast && cd /build/blucast && \
     -DCMAKE_EXE_LINKER_FLAGS='-L/usr/local/VideoFX/lib -L/usr/local/VideoFX/external/tensorrt/lib -L/usr/local/VideoFX/external/cuda/lib -Wl,-rpath,/usr/local/VideoFX/lib:/usr/local/VideoFX/external/tensorrt/lib:/usr/local/VideoFX/external/cuda/lib' && \
     make -j$(nproc)
 
-#FROM docker.io/nvidia/cuda:11.8.0-cudnn8-runtime-ubuntu20.04
 FROM docker.io/nvidia/cuda:12.9.1-cudnn-runtime-ubuntu20.04
 
 LABEL maintainer="BluCast"

--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,6 @@
-FROM docker.io/nvidia/cuda:11.8.0-cudnn8-devel-ubuntu20.04 AS builder
+#FROM docker.io/nvidia/cuda:11.8.0-cudnn8-devel-ubuntu20.04 AS builder
+FROM docker.io/nvidia/cuda:12.9.1-cudnn-devel-ubuntu20.04 AS builder
+
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -6,11 +8,11 @@ RUN apt-get update && apt-get install -y \
     cmake build-essential libopencv-dev libv4l-dev \
     && rm -rf /var/lib/apt/lists/*
 
-COPY sdk/TensorRT-8.5.1.7 /usr/local/TensorRT-8.5.1.7
+COPY sdk/TensorRT /usr/local/TensorRT
 COPY sdk/VideoFX          /usr/local/VideoFX
-COPY sdk/cudnn             /usr/local/cuda/
+#COPY sdk/cudnn             /usr/local/cuda/
 
-ENV LD_LIBRARY_PATH=/usr/local/TensorRT-8.5.1.7/lib:/usr/local/VideoFX/lib:/usr/local/cuda/lib64:$LD_LIBRARY_PATH
+ENV LD_LIBRARY_PATH=/usr/local/VideoFX/external/tensorrt/lib:/usr/local/VideoFX/external/cuda/lib:/usr/local/VideoFX/lib:/usr/local/cuda/lib64:$LD_LIBRARY_PATH
 
 WORKDIR /build
 COPY app/ /app/
@@ -18,10 +20,11 @@ COPY app/ /app/
 RUN mkdir -p /build/blucast && cd /build/blucast && \
     cmake /app \
     -DCMAKE_CXX_FLAGS='-I/usr/local/VideoFX/include -I/usr/local/VideoFX/share/samples/utils' \
-    -DCMAKE_EXE_LINKER_FLAGS='-L/usr/local/VideoFX/lib -Wl,-rpath,/usr/local/VideoFX/lib:/usr/local/TensorRT-8.5.1.7/lib' && \
+    -DCMAKE_EXE_LINKER_FLAGS='-L/usr/local/VideoFX/lib -L/usr/local/VideoFX/external/tensorrt/lib -L/usr/local/VideoFX/external/cuda/lib -Wl,-rpath,/usr/local/VideoFX/lib:/usr/local/VideoFX/external/tensorrt/lib:/usr/local/VideoFX/external/cuda/lib' && \
     make -j$(nproc)
 
-FROM docker.io/nvidia/cuda:11.8.0-cudnn8-runtime-ubuntu20.04
+#FROM docker.io/nvidia/cuda:11.8.0-cudnn8-runtime-ubuntu20.04
+FROM docker.io/nvidia/cuda:12.9.1-cudnn-runtime-ubuntu20.04
 
 LABEL maintainer="BluCast"
 LABEL description="AI-powered virtual camera with NVIDIA VideoFX"
@@ -42,13 +45,18 @@ RUN pip3 install --no-cache-dir PySide6 numpy
 
 COPY --from=builder /build/blucast/blucast_server /app/blucast_server
 
-COPY --from=builder /usr/local/TensorRT-8.5.1.7/lib/libnvinfer.so.8*        /usr/local/lib/blucast/
-COPY --from=builder /usr/local/TensorRT-8.5.1.7/lib/libnvinfer_plugin.so.8* /usr/local/lib/blucast/
-COPY --from=builder /usr/local/TensorRT-8.5.1.7/lib/libnvparsers.so.8*      /usr/local/lib/blucast/
-COPY --from=builder /usr/local/TensorRT-8.5.1.7/lib/libnvonnxparser.so.8*   /usr/local/lib/blucast/
+COPY --from=builder /usr/local/VideoFX/external/tensorrt/lib/libnvinfer.so*        /usr/local/lib/blucast/
+COPY --from=builder /usr/local/VideoFX/external/tensorrt/lib/libnvinfer_dispatch.so* /usr/local/lib/blucast/
+COPY --from=builder /usr/local/VideoFX/external/tensorrt/lib/libnvinfer_plugin.so* /usr/local/lib/blucast/
+COPY --from=builder /usr/local/VideoFX/external/tensorrt/lib/libnvonnxparser.so*   /usr/local/lib/blucast/
+COPY --from=builder /usr/local/VideoFX/external/cuda/lib/*.so.[0-9]* /usr/local/lib/blucast/
 COPY --from=builder /usr/local/VideoFX/lib/libVideoFX.so*     /usr/local/lib/blucast/
+COPY --from=builder /usr/local/VideoFX/lib/libVideoFXLocal.so* /usr/local/lib/blucast/
 COPY --from=builder /usr/local/VideoFX/lib/libNVCVImage.so*   /usr/local/lib/blucast/
 COPY --from=builder /usr/local/VideoFX/lib/libNVTRTLogger.so* /usr/local/lib/blucast/
+COPY --from=builder /usr/local/VideoFX/features/nvvfxgreenscreen/lib/libnvVFXGreenScreen.so /usr/local/lib/blucast/
+COPY --from=builder /usr/local/VideoFX/features/nvvfxbackgroundblur/lib/libnvVFXBackgroundBlur.so /usr/local/lib/blucast/
+COPY --from=builder /usr/local/VideoFX/features/nvvfxdenoising/lib/libnvVFXDenoising.so /usr/local/lib/blucast/
 
 COPY --from=builder /usr/local/VideoFX/lib/models /usr/local/VideoFX/lib/models
 

--- a/Containerfile
+++ b/Containerfile
@@ -9,7 +9,6 @@ RUN apt-get update && apt-get install -y \
 
 COPY sdk/TensorRT /usr/local/TensorRT
 COPY sdk/VideoFX          /usr/local/VideoFX
-#COPY sdk/cudnn             /usr/local/cuda/
 
 ENV LD_LIBRARY_PATH=/usr/local/VideoFX/external/tensorrt/lib:/usr/local/VideoFX/external/cuda/lib:/usr/local/VideoFX/lib:/usr/local/cuda/lib64:$LD_LIBRARY_PATH
 

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Your `sdk/` directory should look like:
 ```
 sdk/
 ├── VideoFX/
-├── TensorRT-8.5.1.7/
+├── TensorRT/
 └── cudnn/
 ```
 

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -12,7 +12,9 @@ set(VFX_SDK     "/usr/local/VideoFX")
 set(VFX_INCLUDE "${VFX_SDK}/include")
 set(VFX_LIB     "${VFX_SDK}/lib")
 set(VFX_SAMPLES "${VFX_SDK}/share/samples")
-set(TRT_ROOT    "/usr/local/TensorRT-8.5.1.7")
+set(TRT_ROOT    "${VFX_SDK}/external/tensorrt")
+set(TRT_LIB     "${TRT_ROOT}/lib")
+set(CUDA_EXT_LIB "${VFX_SDK}/external/cuda/lib")
 
 include_directories(
     ${VFX_INCLUDE}
@@ -22,7 +24,7 @@ include_directories(
     ${CUDA_INCLUDE_DIRS}
 )
 
-link_directories(${VFX_LIB} ${TRT_ROOT}/lib)
+link_directories(${VFX_LIB} ${TRT_LIB} ${CUDA_EXT_LIB})
 
 add_executable(blucast_server server.cpp)
 
@@ -35,6 +37,6 @@ target_link_libraries(blucast_server
 )
 
 set_target_properties(blucast_server PROPERTIES
-    BUILD_RPATH  "${VFX_LIB};${TRT_ROOT}/lib"
-    INSTALL_RPATH "${VFX_LIB};${TRT_ROOT}/lib"
+    BUILD_RPATH  "${VFX_LIB};${TRT_LIB};${CUDA_EXT_LIB}"
+    INSTALL_RPATH "${VFX_LIB};${TRT_LIB};${CUDA_EXT_LIB}"
 )

--- a/app/control_panel.py
+++ b/app/control_panel.py
@@ -818,7 +818,10 @@ def main():
         app.setWindowIcon(QIcon(LOGO_PATH))
 
     window = ControlPanel()
-    window.show()
+    if window.tray_available and window.tray_icon.isVisible():
+        send_command("WINDOW:hidden")
+    else:
+        window.show()
     sys.exit(app.exec())
 
 

--- a/app/server.cpp
+++ b/app/server.cpp
@@ -21,6 +21,19 @@
 #include "nvVideoEffects.h"
 #include "opencv2/opencv.hpp"
 
+// VFX SDK 1.2 moved effect selector defines into per-feature headers that are
+// not on the default include path. Keep local fallbacks for the selectors used
+// by BluCast while preserving compatibility with older SDK headers.
+#ifndef NVVFX_FX_GREEN_SCREEN
+#define NVVFX_FX_GREEN_SCREEN "GreenScreen"
+#endif
+#ifndef NVVFX_FX_BGBLUR
+#define NVVFX_FX_BGBLUR "BackgroundBlur"
+#endif
+#ifndef NVVFX_FX_DENOISING
+#define NVVFX_FX_DENOISING "Denoising"
+#endif
+
 //  Paths ───────────────────────────────────────────────────────────────
 static const char *SHARED_DIR      = "/tmp/blucast";
 static const char *CMD_PIPE_PATH   = "/tmp/blucast/cmd.pipe";
@@ -32,7 +45,7 @@ static const char *VCAM_DEVICE     = "/dev/video10";
 
 //  Global state
 static std::atomic<bool>  g_running{true};
-static std::atomic<bool>  g_windowVisible{true};
+static std::atomic<bool>  g_windowVisible{false};
 static std::atomic<int>   g_effectMode{6};
 static std::atomic<float> g_blurStrength{0.5f};
 static std::atomic<int>   g_cameraWidth{1280};
@@ -223,7 +236,8 @@ public:
         std::cout << "Loading AI model..." << std::endl;
         err = NvVFX_Load(eff_);
         if (err != NVCV_SUCCESS) {
-            std::cerr << "Error loading model: " << err << std::endl;
+            std::cerr << "Error loading model: " << err
+                      << " (" << NvCV_GetErrorStringFromCode(err) << ")" << std::endl;
             return false;
         }
         std::cout << "Model loaded." << std::endl;
@@ -239,8 +253,8 @@ public:
             bgblurEff_ = nullptr;
         }
 
-        // Artifact reduction (denoise)
-        if (NvVFX_CreateEffect(NVVFX_FX_ARTIFACT_REDUCTION, &artifactEff_) == NVCV_SUCCESS) {
+        // Webcam denoising
+        if (NvVFX_CreateEffect(NVVFX_FX_DENOISING, &artifactEff_) == NVCV_SUCCESS) {
             NvVFX_SetCudaStream(artifactEff_, NVVFX_CUDA_STREAM, stream_);
             NvVFX_SetString(artifactEff_, NVVFX_MODEL_DIRECTORY, modelDir.c_str());
         } else {

--- a/install.sh
+++ b/install.sh
@@ -133,7 +133,7 @@ if [ -f "$SCRIPT_DIR/sdk.tar.gz" ] && [ ! -d "$SDK_DIR/VideoFX" ]; then
     tar -xzf "$SCRIPT_DIR/sdk.tar.gz" -C "$SCRIPT_DIR"
 fi
 [ -d "$SDK_DIR/VideoFX" ]           || die "VideoFX SDK not found in sdk/"
-[ -d "$SDK_DIR/TensorRT-8.5.1.7" ]  || die "TensorRT SDK not found in sdk/"
+[ -d "$SDK_DIR/TensorRT" ]           || die "TensorRT SDK not found in sdk/"
 [ -d "$SDK_DIR/cudnn" ]              || die "cuDNN libraries not found in sdk/"
 log "All SDK components present"
 

--- a/run.sh
+++ b/run.sh
@@ -6,7 +6,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 VCAM_DEVICE="/dev/video10"
 SHARED_DIR="/tmp/blucast"
 GHCR_IMAGE="ghcr.io/andrei9383/blucast:latest"
-LOCAL_IMAGE="localhost/blucast:latest"
+LOCAL_IMAGES=("localhost/blucast:latest" "blucast:latest")
 
 if command -v podman &>/dev/null; then
     CONTAINER_CMD="podman"
@@ -15,17 +15,6 @@ elif command -v docker &>/dev/null; then
 else
     echo "Error: podman or docker required"
     exit 1
-fi
-
-if $CONTAINER_CMD image exists "$LOCAL_IMAGE" 2>/dev/null || \
-   $CONTAINER_CMD inspect "$LOCAL_IMAGE" &>/dev/null 2>&1; then
-    IMAGE_NAME="$LOCAL_IMAGE"
-else
-    IMAGE_NAME="$GHCR_IMAGE"
-    if ! $CONTAINER_CMD inspect "$IMAGE_NAME" &>/dev/null 2>&1; then
-        echo "Pulling BluCast image..."
-        $CONTAINER_CMD pull "$IMAGE_NAME"
-    fi
 fi
 
 if [ ! -e "$VCAM_DEVICE" ]; then
@@ -90,6 +79,22 @@ cleanup() {
           "$SHARED_DIR/server.pid" "$SHARED_DIR/.xauth"
 }
 trap cleanup EXIT
+
+IMAGE_NAME=""
+for image in "${LOCAL_IMAGES[@]}"; do
+    if $CONTAINER_CMD image exists "$image" 2>/dev/null || \
+       $CONTAINER_CMD inspect "$image" &>/dev/null 2>&1; then
+        IMAGE_NAME="$image"
+        break
+    fi
+done
+if [ -z "$IMAGE_NAME" ]; then
+    IMAGE_NAME="$GHCR_IMAGE"
+    if ! $CONTAINER_CMD inspect "$IMAGE_NAME" &>/dev/null 2>&1; then
+        echo "Pulling BluCast image..."
+        $CONTAINER_CMD pull "$IMAGE_NAME"
+    fi
+fi
 
 if [ "$CONTAINER_CMD" = "podman" ]; then
     GPU_ARGS="--device nvidia.com/gpu=all"


### PR DESCRIPTION
## Description

This PR updates the container build and runtime paths for the current NVIDIA VideoFX SDK layout.

- Use the generic `sdk/TensorRT` directory instead of a versioned `sdk/TensorRT-8.5.1.7` path.
- Point CMake and container runtime paths at VideoFX-provided TensorRT/CUDA external libraries.
- Copy the additional VideoFX and feature libraries required by the newer SDK layout.
- Add local fallback definitions for VideoFX effect selector names moved out of the default SDK include path.
- Use the VideoFX denoising effect selector for webcam denoising.
- Prefer locally built Docker image tags in `run.sh` before falling back to GHCR.
- Keep the GUI hidden at startup when the tray icon is available.
- Update README SDK directory documentation to use `TensorRT/`.
- NVIDIA VideoFX SDK: `1.2.0.0` via `sdk/VideoFX -> VFXSDK_linux_1.2.0.0`
- NVIDIA TensorRT: `10.16.1.11` via `sdk/TensorRT -> TensorRT-10.16.1.11`
- NVIDIA cuDNN: `9.21.1.3` for CUDA 12 via `sdk/cudnn -> cudnn-linux-x86_64-9.21.1.3_cuda12-archive`


## Type of Change

<!-- Mark with an `x` all that apply -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [x] Code refactoring
- [ ] Performance improvement

## Related Issues

Fixes #3 #4 #5  #8 

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [x] Tested with different effect modes
- [x] Tested virtual camera output in a video app
- [x] Tested on my GPU: 4060
- [x] No new warnings or errors
- [x] Tested on my OS: Ubuntu 26.04 LTS + Wayland

## Checklist

- [x] My code follows the project's code style
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings
- [x] I have updated documentation if needed
